### PR TITLE
Update android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+  - name: set up JDK 1.8
+  uses: actions/setup-java@v4
+  with:
+    java-version: 1.8
+    distribution: temurin


### PR DESCRIPTION
Update the .github/workflows/android.yml file to include the distribution parameter under the setup-java step.

The distribution parameter specifies which JDK distribution to use. In this example, temurin is chosen, which is a widely used and recommended JDK distribution. You can replace temurin with another distribution if needed.

After making this change, the workflow should execute successfully without the "Input required and not supplied: distribution" error.